### PR TITLE
Add label clarification on integrations with a major release

### DIFF
--- a/guides/integration-release.md
+++ b/guides/integration-release.md
@@ -29,7 +29,7 @@ The [Release Drafter tool](./release-drafter.md), integrated into most repositor
 
 Also, when writing the final changelogs, you might notice some inconsistencies, e.g., a PR that should have been identified as a breaking change or a PR that should not appear in the changelogs: in this case, please, do not update the release description manually. Instead:
 - Go to the related PR.
-- Add the missing label (`breaking-change` or `skip-changelog`).
+- Add the missing label (`breaking-change`, `new feature` or `skip-changelog`, [see guide](./release-drafter#how-does-the-release-drafter-work)).
 - Re-run the last `Release Drafter` job in the `Actions` tab of the repository.
 
 > 💡 How to re-run the "Release Drafter" job?

--- a/guides/integration-release.md
+++ b/guides/integration-release.md
@@ -29,7 +29,7 @@ The [Release Drafter tool](./release-drafter.md), integrated into most repositor
 
 Also, when writing the final changelogs, you might notice some inconsistencies, e.g., a PR that should have been identified as a breaking change or a PR that should not appear in the changelogs: in this case, please, do not update the release description manually. Instead:
 - Go to the related PR.
-- Add the missing label (`breaking-change`, `new feature` or `skip-changelog`, [see guide](./release-drafter#how-does-the-release-drafter-work)).
+- Add the missing label (`breaking-change`, `new-feature` or `skip-changelog`, [see guide](./release-drafter#how-does-the-release-drafter-work)).
 - Re-run the last `Release Drafter` job in the `Actions` tab of the repository.
 
 > 💡 How to re-run the "Release Drafter" job?

--- a/guides/release-drafter.md
+++ b/guides/release-drafter.md
@@ -16,6 +16,10 @@ If you don't have the right access to this repository, you will not be able to s
 
 The draft release description is therefore generated and corresponds to all the PRs titles since the previous release. **This means each PR should only do one change, and the title should be descriptive of this change**.
 
+### SemVer and Versioning
+
+MeiliSearch tools follow the [Semantic Versioning Convention](https://semver.org/). Based on the chosen labels for a PR, the release-drafter automatically increases the right number in the version.
+
 ### Skip the PR
 
 If you don't want a PR to appear in the release changelogs: add the label `skip-changelog`.
@@ -24,36 +28,22 @@ We suggest removing PRs updating the README or the CI. Users don't need this kin
 
 ### The PR adds a new feature
 
-⚠️ Only for integrations that has a major version release (`1.x.x`, `2.x.x`).
+⚠️ Only for integrations that have a major release version (e.g. `1.x.x`, `2.x.x`).
 
-If the PR introduces a new feature: add the label `new-feature`
+If the PR introduces a new feature: add the label `new-feature`.
 
-the PR is made has already a major version , then, a `Pull request` introducing a new feature should have the `new-feature` label.  
-
-Ex: `1.1.3` -> `1.2.0`
+The minor version of the release increases.
+Ex: `0.1.4` -> `0.2.0`
 
 ### The PR implies breaking changes
 
 If the changes you are doing in the PR are breaking: add the label `breaking-change`.
 
-### SemVer and Versioning
+- If the integration is not stable (e.g. `0.X.Y`) the minor version increases.
+Ex: `0.1.4` -> `0.2.0`
 
-MeiliSearch tools follow the [Semantic Versioning Convention](https://semver.org/). Based on the chosen labels for a PR, the release-drafter will automatically increase the right number in the version. 
-
-#### In integrations with no major release (`0.x.x`)
-
-- `skip-changelog` or no labels does not impact versioning, except if it is the first accepted PR. In which case, the `patch` number increases.
-- `breaking-changes` increases the minor version automatically, ex: `0.2.3` -> `0.3.0`
-
-#### In integrations with a major release ((`1.x.x`, `2.x.x`)
-
-- `skip-changelog` or no labels, does not impact versionning, except if it is the first accepted PR. In which case, the `patch` number increases.
-- `new-feature`: Increases the minor version automatically, ex: `0.2.3` -> `0.3.0`
-- `breaking-changes` Increases the major version automatically, ex: `1.2.4` -> `2.0.0`
-
-The order is important as `breaking-change` will override the version change of a `new-feature`. If both labels are present in a release, only the major version increases.
-
-Integrations with a major release are an exception. Other integrations will have no major release until [MeiliSearch](https://github.com/meilisearch/MeiliSearch) is stable.
+- If the integration is stable (e.g. `X.Y.Z` when `X > 0`) the major version increases.
+Ex: `2.1.4` -> `3.0.0`
 
 ### Other Recommendations
 

--- a/guides/release-drafter.md
+++ b/guides/release-drafter.md
@@ -22,11 +22,38 @@ If you don't want a PR to appear in the release changelogs: add the label `skip-
 
 We suggest removing PRs updating the README or the CI. Users don't need this kind of information when updating the package.
 
+### The PR adds a new feature
+
+⚠️ Only for integrations that has a major version release (`1.x.x`, `2.x.x`).
+
+If the PR introduces a new feature: add the label `new-feature`
+
+the PR is made has already a major version , then, a `Pull request` introducing a new feature should have the `new-feature` label.  
+
+Ex: `1.1.3` -> `1.2.0`
+
 ### The PR implies breaking changes
 
 If the changes you are doing in the PR are breaking: add the label `breaking-change`.
 
-MeiliSearch tools follow the [Semantic Versioning Convention](https://semver.org/). In the release tag, the minor will be increased instead of the patch. The major will never be changed until [MeiliSearch](https://github.com/meilisearch/MeiliSearch) is stable.
+### SemVer and Versioning
+
+MeiliSearch tools follow the [Semantic Versioning Convention](https://semver.org/). Based on the chosen labels for a PR, the release-drafter will automatically increase the right number in the version. 
+
+#### In integrations with no major release (`0.x.x`)
+
+- `skip-changelog` or no labels does not impact versioning, except if it is the first accepted PR. In which case, the `patch` number increases.
+- `breaking-changes` increases the minor version automatically, ex: `0.2.3` -> `0.3.0`
+
+#### In integrations with a major release ((`1.x.x`, `2.x.x`)
+
+- `skip-changelog` or no labels, does not impact versionning, except if it is the first accepted PR. In which case, the `patch` number increases.
+- `new-feature`: Increases the minor version automatically, ex: `0.2.3` -> `0.3.0`
+- `breaking-changes` Increases the major version automatically, ex: `1.2.4` -> `2.0.0`
+
+The order is important as `breaking-change` will override the version change of a `new-feature`. If both labels are present in a release, only the major version increases.
+
+Integrations with a major release are an exception. Other integrations will have no major release until [MeiliSearch](https://github.com/meilisearch/MeiliSearch) is stable.
 
 ### Other Recommendations
 


### PR DESCRIPTION
Add clarification on labels when used in an integration with a major release

[See related](https://github.com/meilisearch/docs-searchbar.js/pull/370)