### PR TITLE
Update cypress example

### DIFF
--- a/guides/cypress.md
+++ b/guides/cypress.md
@@ -76,7 +76,7 @@ describe(`My first test`, () => {
   })
 
   it('Should visit the dashboard', () => {
-    cy.url().should('match', /http:\/\/localhost:8080/) // The current host URL
+    cy.url().should('match', new RegExp(HOST)) // The current host URL
   })
 })
 ```


### PR DESCRIPTION
Update the Cypress example to avoid `HOST` repetition