### PR TITLE
Update release drafter guide according to the new label process

### DIFF
--- a/resources/release-drafter.md
+++ b/resources/release-drafter.md
@@ -20,22 +20,19 @@ The draft release description is therefore generated and corresponds to all the 
 
 MeiliSearch tools follow the [Semantic Versioning Convention](https://semver.org/). Based on the chosen labels for a PR, the release-drafter automatically increases the right number in the version.
 
-### Skip the PR
+### Label the PR
+
+Each PR should be labelled by one of the following labels: `skip-changelog`, `breaking-change`, `security`, `enhancement` or `bug`.
+
+According to the label you choose, the changelog will be put in the related section in the release draft. It means you cannot mix them in the same PR.
+
+#### `skip-changelog`
 
 If you don't want a PR to appear in the release changelogs: add the label `skip-changelog`.
 
 We suggest removing PRs updating the README or the CI. Users don't need this kind of information when updating the package.
 
-### The PR adds a new feature
-
-⚠️ Only for integrations that have a major release version (e.g. `1.x.x`, `2.x.x`).
-
-If the PR introduces a new feature: add the label `new-feature`.
-
-The minor version of the release increases.
-Ex: `0.1.4` -> `0.2.0`
-
-### The PR implies breaking changes
+#### `breaking-change`
 
 If the changes you are doing in the PR are breaking: add the label `breaking-change`.
 
@@ -44,6 +41,24 @@ Ex: `0.1.4` -> `0.2.0`
 
 - If the integration is stable (e.g. `X.Y.Z` when `X > 0`) the major version increases.
 Ex: `2.1.4` -> `3.0.0`
+
+#### `enhancement`
+
+If the PR introduces a new feature or a new improvement: add the label `enhancement`.
+
+For integrations that are stable and so have a major release version (e.g. `1.x.x`, `2.x.x`), this will make the minor increase (e.g. `1.2.4` -> `1.3.0`).
+
+#### `bug`
+
+If the PR fixes bugs: add the label `bug`.
+
+A bug could be an unexpected raised error, but also a loss of performance, or any unexpected behavior of the integration.
+
+#### `security`
+
+If the PR fixes a securtiy issue: add the label `security`.
+
+Most of the time, this concerns PRs fixing dependencies issues on which security vulnerabilities have been reported.
 
 ### Other Recommendations
 

--- a/resources/release-drafter.md
+++ b/resources/release-drafter.md
@@ -56,7 +56,7 @@ A bug could be an unexpected raised error, but also a loss of performance, or an
 
 #### `security`
 
-If the PR fixes a securtiy issue: add the label `security`.
+If the PR fixes a security issue: add the label `security`.
 
 Most of the time, this concerns PRs fixing dependencies issues on which security vulnerabilities have been reported.
 

--- a/resources/release-drafter.md
+++ b/resources/release-drafter.md
@@ -44,7 +44,7 @@ Ex: `2.1.4` -> `3.0.0`
 
 #### `enhancement`
 
-If the PR introduces a new feature or a new improvement: add the label `enhancement`.
+If the PR introduces a new feature or an improvement: add the label `enhancement`.
 
 For integrations that are stable and so have a major release version (e.g. `1.x.x`, `2.x.x`), this will make the minor increase (e.g. `1.2.4` -> `1.3.0`).
 

--- a/resources/release-drafter.md
+++ b/resources/release-drafter.md
@@ -52,7 +52,7 @@ For integrations that are stable and so have a major release version (e.g. `1.x.
 
 If the PR fixes bugs: add the label `bug`.
 
-A bug could be an unexpected raised error, but also a loss of performance, or any unexpected behavior of the integration.
+A bug could be a raised error, a loss of performance, or any unexpected behavior of the integration.
 
 #### `security`
 

--- a/resources/release-drafter.md
+++ b/resources/release-drafter.md
@@ -58,7 +58,7 @@ A bug could be a raised error, a loss of performance, or any unexpected behavior
 
 If the PR fixes a security issue: add the label `security`.
 
-Most of the time, this concerns PRs fixing dependencies issues on which security vulnerabilities have been reported.
+Most of the time, this concerns PRs fixing dependencies issues on which security vulnerabilities are reported.
 
 ### Other Recommendations
 


### PR DESCRIPTION
⚠️ Should be merged with the approval of @alallema AND @bidoubiwa 

This PR
- adds the section related to the new label process we validated during meetings and here: https://github.com/meilisearch/meilisearch-python/pull/320
- fixes this issue: https://github.com/meilisearch/integration-guides/issues/148. The "breaking change" section is now at the top of the release draft since there is no more "Change" default section
- removes the `new-feature` label for the stable integrations, since we might replace it by `enhancement`. Discussion here: https://github.com/meilisearch/docs-searchbar.js/pull/476