### PR TITLE
Add the integration team demo resource

### DIFF
--- a/resources/README.md
+++ b/resources/README.md
@@ -8,6 +8,8 @@ Here are the different guides for the Integration team.
 - [Releasing an Integration](./integration-release.md)
 - [Issues](./issues.md)
 - [Build an Integration](./build-integration.md)
+- [Developer Scopes](./scopes.md)
+- [Demos](./demos.md)
 
 ## 🔧 Automation Tools
 

--- a/resources/demos.md
+++ b/resources/demos.md
@@ -1,0 +1,12 @@
+## Integration team demos
+
+The integration team is also responsible for maintaining the following code-sandbox demos:
+
+- [MeiliSearch + InstantSearch](https://codesandbox.io/s/ms-is-mese9?fontsize=14&hidenavigation=1&theme=dark)
+- [MeiliSearch + Vue InstantSearch](https://codesandbox.io/s/ms-vue-is-1d6bi?fontsize=14&hidenavigation=1&theme=dark&file=/src/App.vue)
+- [MeiliSearch + React InstantSearch](https://codesandbox.io/s/ms-angularis-7xipe)
+- [MeiliSearch + Angular InstantSearch](https://codesandbox.io/s/ms-angularis-7xipe)
+
+This code-sandboxes are used in the corresponding front-end integration READMEs.
+
+These demos are using the same `steam-video-games` index in the same MeiliSearch instance on `https://integration-demos.meilisearch.com`.

--- a/resources/demos.md
+++ b/resources/demos.md
@@ -1,6 +1,21 @@
-## Integration team demos
+# Integration team demos
 
-The integration team is also responsible for maintaining the following code-sandbox demos:
+The integration team is also responsible for maintaining some MeiliSearch indexes and demos that can be useful for the users and the developers.
+
+## MeiliSearch instance
+
+The MeiliSearch instance maintained by the integration team is available on `https://integration-demos.meilisearch.com`. Ask an administrator to get the master key.
+
+This instance contains the indexes officially used by the integration team for demos, playgrounds...
+
+Here are the exhaustive list of the indexes:
+
+- `steam-video-games` used by the code-sandboxes mentionned in the following section.
+- `world_cities` used in the [instant-meilisearch playground related to geo-search](https://github.com/meilisearch/instant-meilisearch/tree/main/playgrounds/geo-javascript).
+
+## Code sandboxes
+
+The following code-sandbox demos related to InstantSearch are maintained:
 
 - [MeiliSearch + InstantSearch](https://codesandbox.io/s/ms-is-mese9?fontsize=14&hidenavigation=1&theme=dark)
 - [MeiliSearch + Vue InstantSearch](https://codesandbox.io/s/ms-vue-is-1d6bi?fontsize=14&hidenavigation=1&theme=dark&file=/src/App.vue)
@@ -9,4 +24,4 @@ The integration team is also responsible for maintaining the following code-sand
 
 This code-sandboxes are used in the corresponding front-end integration READMEs.
 
-These demos are using the same `steam-video-games` index in the same MeiliSearch instance on `https://integration-demos.meilisearch.com`.
+These demos are using the same `steam-video-games` index.


### PR DESCRIPTION
Add a small guide to describe what are the only demos the integration team owns.