### PR TITLE
Add code sandbox for vue3

### DIFF
--- a/resources/demos.md
+++ b/resources/demos.md
@@ -18,7 +18,8 @@ Here are the exhaustive list of the indexes:
 The following code-sandbox demos related to InstantSearch are maintained:
 
 - [Meilisearch + InstantSearch](https://codesandbox.io/s/ms-is-mese9?fontsize=14&hidenavigation=1&theme=dark)
-- [Meilisearch + Vue InstantSearch](https://codesandbox.io/s/ms-vue-is-1d6bi?fontsize=14&hidenavigation=1&theme=dark&file=/src/App.vue)
+- [Meilisearch + Vue 2 InstantSearch](https://codesandbox.io/s/ms-vue-is-1d6bi?fontsize=14&hidenavigation=1&theme=dark&file=/src/App.vue)
+- [Meilisearch + Vue 3 InstantSearch](https://codesandbox.io/s/ms-vue3-is-0293zk?file=/src/App.vue)
 - [Meilisearch + React InstantSearch](https://codesandbox.io/s/ms-angularis-7xipe)
 - [Meilisearch + Angular InstantSearch](https://codesandbox.io/s/ms-angularis-7xipe)
 


### PR DESCRIPTION
Compatibility with vue3 has been required a lot. We were in fact compatible but an example was missing to show how to do so. 

See popular content. First is readme and second is the vue3 compatibility. 

<img width="445" alt="Screenshot 2022-05-02 at 17 37 56" src="https://user-images.githubusercontent.com/33010418/166263006-0d58452d-d071-476e-88a7-c28a282a9596.png">

see this issue: https://github.com/meilisearch/meilisearch-vue/issues/102