### PR TITLE
Create list of labels to use in the sdk's issues

### DIFF
--- a/guides/sdk-labels.md
+++ b/guides/sdk-labels.md
@@ -1,0 +1,37 @@
+# SDK's issues Labels
+
+⚠️ These labels are not the same as this repo's labels. They are meant to be used to tag the issues opened in the different SDK's repositories.
+
+We have many issues in every integration repository. These help us understand what each issue is about or its state.
+A clear label prevents us from re-reading the issue when we are scanning them, and they provide a context in the blink of an eye.
+
+Nonetheless, until now, every repo used its own label system. Thus, to avoid adapting to every repo's label choices, we want to create a consistent labels list to use.
+
+These are the labels that are encouraged to use.
+
+## Default labels
+
+They already exist in every repo.
+
+| label Name  | Color  | description  |
+|---|---|---|
+|`bug` | #d73a4a | Something isn't working |
+| `good first issue` | #7057ff | Good for newcomers |
+| `help wanted` | #008672 | Extra attention is needed |
+| `enhancement` | #a2eeef | New feature or request |
+| `security` | #ee0701 | Pull request or issue that has recieve no activity for a long time. |
+
+## Custom labels
+
+They need to be added manually
+
+| label Name  | Color  | description |
+|---|---|---|
+| `support` | #F78FB2| Issues related to support questions. |
+| `spam`  | #006B75  | PR/Issue considered as a spam.  |
+| `needs investigation`  | #006B75  | Needs to take time to understand the issue.  |
+| `needs more info`  | #5319e7  |  This issue needs a minimal complete and verifiable example. |
+| `maintenance` | #DBA7A9  | Issue about maintenance (CI, tests, refacto...) |
+| `stale` | #A2A0D6 | Pull request or issue that has recieve no activity for a long time. |
+
+Side note, labels can be easily forgotten. We strongly encourage its use, but we want to observe if we naturally apply them before making them mandatory. We also want to observe if some labels are missing or never used.


### PR DESCRIPTION
These are the labels we encourage to use.

One question for me remains is the `question` vs `support` tag.
I found myself using the `question` tag often to answer specific questions about the SDK. It act like a `triage` label in te sense where we discuss with the contributor until we find a common ground. After which I would label the issue `enhancement` or just close it if it's not going anywhere. 