### PR TITLE
Add planning to the next quarter (Q3)

### DIFF
--- a/roadmap/2022.md
+++ b/roadmap/2022.md
@@ -142,4 +142,6 @@ Maintenance:
   - [ ] Create a strategy plan to refactor the Java SDK.
   - [ ] Add okhttp as hard dependency (to support PATCH methods).
   - [ ] Remove duplicated code
+  - [ ] Add tests to [cover some parts of the code](https://github.com/meilisearch/strapi-plugin-meilisearch/issues/351) in strapi-plugin-meilisearch that is not tested at all.
+  - [ ] Remove support for `Node v12` ensure support for `Node v18` in every javascript repo.
   - [ ] _TBD_

--- a/roadmap/2022.md
+++ b/roadmap/2022.md
@@ -143,6 +143,6 @@ Maintenance:
   - [ ] Create a strategy plan to refactor the Java SDK.
   - [ ] Add okhttp as hard dependency (to support PATCH methods).
   - [ ] Remove duplicated code
-  - [ ] Add tests to [cover some parts of the code](https://github.com/meilisearch/strapi-plugin-meilisearch/issues/351) in strapi-plugin-meilisearch that is not tested at all.
-  - [ ] Remove support for `Node v12` ensure support for `Node v18` in every javascript repo.
-  - [ ] _TBD_
+ - [ ] Add tests to [cover some parts of the code](https://github.com/meilisearch/strapi-plugin-meilisearch/issues/351) in strapi-plugin-meilisearch that is not tested at all.
+ - [ ] Remove support for `Node v12` ensure support for `Node v18` in every javascript repo.
+ - [ ] _TBD_

--- a/roadmap/2022.md
+++ b/roadmap/2022.md
@@ -92,9 +92,18 @@ Meilisearch releases:
 
 ## Q3
 
+The general idea for the 3rd quarter is:
+
+- Have all of our integrations (but DevOps tools) with the analytics implementation, to give us data to improve our decision-making in the future.
+- Finish ongoing projects like documentation and docker.
+- Ruby community is the 3rd most used according to our internal metrics, and we have some features asked by the users that could be implemented with a small-time effort. The same idea can be applied to the Symfony integration, not necessarily with new features, but maintenance in general.
+- Java is a whole subject apart since it has a huge maintainability problem because it has a double implementation and has a lack of support for the PATCH method.
+
+With that thought in mind, we should be able to start planning new integrations in the next quarters since we will have dealt with most of the critical issues/finished some working-in-progress jobs in this quarter.
+
 Meilisearch releases:
 - [ ] [v0.28 work](https://github.com/meilisearch/integration-guides/issues/205):
-  - [ ] New API namings, could impact multiple resources and nomenclatures, like dumps, keys, search, and indexes.
+  - [ ] New API namings, will impact multiple resources and nomenclatures, like dumps, documents, keys, tasks, search, and indexes.
   - [ ] New behavior to update keys
   - [ ] HTTP verbs changes
   - [ ] Add pagination to the multiple API resources (keys, tasks, indexes, documents).
@@ -115,6 +124,9 @@ Misc:
   - [ ] VuePress
   - [ ] Firebase
   - [x] .Net, Dart, Golang, PHP, Python, Ruby, Rust, Swift.
+- [ ] Start tidying up all the repositories for the Hacktoberfest.
+  - [ ] Removing old issues that are outdated or don't make much sense anymore.
+  - [ ] Creating new issues labeled `good first issue`.
 
 Improvements:
 - [ ] Add a helpful docker/compose setup on [these integrations](https://github.com/meilisearch/integration-guides/issues/199):
@@ -141,8 +153,7 @@ Maintenance:
 - [ ] Enhance `pagy` documentation in the meilisearch-rails.
 - [ ] Java refactor to increase the contributability:
   - [ ] Create a strategy plan to refactor the Java SDK.
-  - [ ] Add okhttp as hard dependency (to support PATCH methods).
+  - [ ] Add `okhttp` as hard dependency (to support PATCH methods).
   - [ ] Remove duplicated code
  - [ ] Add tests to [cover some parts of the code](https://github.com/meilisearch/strapi-plugin-meilisearch/issues/351) in strapi-plugin-meilisearch that is not tested at all.
- - [ ] Remove support for `Node v12` ensure support for `Node v18` in every javascript repo.
- - [ ] _TBD_
+ - [ ] Remove support for `Node v12` ensure support for `Node v18` in every JavaScript repo.

--- a/roadmap/2022.md
+++ b/roadmap/2022.md
@@ -89,3 +89,55 @@ Meilisearch releases:
   - [ ] Add pagination to the multiple API resources (keys, tasks, indexes, documents).
   - [ ] Changes related to the dumps resources
   - [ ] Add PATCH support to Java SDK.
+
+## Q3
+
+Meilisearch releases:
+- [ ] [v0.28 work](https://github.com/meilisearch/integration-guides/issues/205):
+  - [ ] New API namings, could impact multiple resources and nomenclatures, like dumps, keys, search, and indexes.
+  - [ ] New behavior to update keys
+  - [ ] HTTP verbs changes
+  - [ ] Add pagination to the multiple API resources (keys, tasks, indexes, documents).
+  - [ ] Changes related to the dumps resources
+  - [ ] Add PATCH support to Java SDK.
+
+Misc:
+- [ ] Add analytics to these integrations:
+  - [ ] Javascript
+  - [ ] Java
+  - [ ] Strapi
+  - [ ] Laravel?
+  - [ ] Ruby on Rails
+  - [ ] Symfony
+  - [ ] Instant Meilisearch
+  - [ ] Docs Searchbar
+  - [ ] Gatsby
+  - [ ] VuePress
+  - [ ] Firebase
+  - [x] .Net, Dart, Golang, PHP, Python, Ruby, Rust, Swift.
+
+Improvements:
+- [ ] Add a helpful docker/compose setup on [these integrations](https://github.com/meilisearch/integration-guides/issues/199):
+  - [ ] .Net
+  - [ ] Golang
+  - [ ] Rust
+  - [ ] Instant Meilisearch
+  - [x] Dart, Java, JavaScript, PHP, Python, Ruby, Ruby on Rails, Symfony.
+
+New features:
+- [ ] Add multi-index (federated search) in [instant-meilisearch](https://github.com/meilisearch/instant-meilisearch/issues/774).
+- [ ] On/Off switcher in [meilisearch-rails](https://github.com/meilisearch/meilisearch-rails/issues/140).
+- [ ] Improve performance in meilisearch-rails by reducing the payload size with `attributesToRetrieve` automatically.
+- [ ] Add auto generated documentation [in some of the SDKs](https://github.com/meilisearch/integration-guides/issues/201):
+  - [ ] JavaScript
+  - [ ] PHP
+  - [ ] Python
+  - [x] Rust, Dart
+
+Maintenance:
+- [ ] Enhance `pagy` documentation in the meilisearch-rails.
+- [ ] Java refactor to increase the contributability:
+  - [ ] Create a strategy plan to refactor the Java SDK.
+  - [ ] Add okhttp as hard dependency (to support PATCH methods).
+  - [ ] Remove duplicated code
+  - [ ] _TBD_

--- a/roadmap/2022.md
+++ b/roadmap/2022.md
@@ -133,6 +133,8 @@ New features:
   - [ ] PHP
   - [ ] Python
   - [x] Rust, Dart
+- [ ] Make zero facet appearing even when using placeholder search in [instant-meilisearch](https://github.com/meilisearch/instant-meilisearch/issues/775).
+- [ ] Make strapi-plugin-meilisearch for v3 of Strapi  [compatible with the latest of Meilisearch](https://github.com/meilisearch/strapi-plugin-meilisearch/issues/444).
 
 Maintenance:
 - [ ] Enhance `pagy` documentation in the meilisearch-rails.

--- a/roadmap/2022.md
+++ b/roadmap/2022.md
@@ -135,6 +135,7 @@ New features:
   - [x] Rust, Dart
 - [ ] Make zero facet appearing even when using placeholder search in [instant-meilisearch](https://github.com/meilisearch/instant-meilisearch/issues/775).
 - [ ] Make strapi-plugin-meilisearch for v3 of Strapi  [compatible with the latest of Meilisearch](https://github.com/meilisearch/strapi-plugin-meilisearch/issues/444).
+- [ ] Add disjunctive facet search to [instant-meilisearch]([instant-meilisearch](https://github.com/meilisearch/instant-meilisearch)) (issue creation + implementation)
 
 Maintenance:
 - [ ] Enhance `pagy` documentation in the meilisearch-rails.


### PR DESCRIPTION
The general idea for the next quarter is:

- Have all of our integrations (but DevOps tools) with the analytics implementation, to give us data to improve our decision-making for the next quarters.
- Finish some projects started in the other quarters, like documentation and docker.
- Ruby community is the 3rd most used according to our internal metrics, and we have some features asked by the users that could be implemented with a small-time effort. The same idea can be applied to the Symfony integration, not necessarily with new features, but maintenance in general.
- Java is a whole subject apart since it has a huge maintainability problem because it has a double implementation and has a lack of support for the PATCH method.


With that thought in mind, we should be able to start planning new integrations in the next quarters since we will have dealt with most of the critical issues/finished some working-in-progress jobs in this quarter.