### PR TITLE
Change the wrongly named docsscrapper bullet point in the roadmap

### DIFF
--- a/roadmap/2022.md
+++ b/roadmap/2022.md
@@ -195,7 +195,7 @@ Maintenance:
 New projects:
 - [ ] Implement packer.io to build Meilisearch images for the cloud providers.
 - [ ] Build the action plan to create the MVP of the new Laravel-Scout-Integration-Extended on our side.
-- [ ] "Docscraper 2.0":
+- [x] Autocomplete compatibility:
   - [x] Do the complete research around autocomplete.js and docsearchbar v2 support with our JavaScript client.
   - [x] Provide the action plan to add support for those libraries in case they are incompatible.
 


### PR DESCRIPTION
Docs-scraper has nothing to do with autocomplete, so I changed the name.